### PR TITLE
Cannot update offsets of units that have ID >= 10

### DIFF
--- a/FlapFunctions.cpp
+++ b/FlapFunctions.cpp
@@ -63,7 +63,7 @@ void commitStagedUnitStates()
 
   for (int i = 0; i < numUnits; i++)
   {
-    int address = i;
+    int address = stagedUnitStates[i].unitAddr;
     int offset = stagedUnitStates[i].offset;
     int magneticZeroPositionLetterUpdateIndex = stagedUnitStates[i].magneticZeroPositionLetterIndex;
 
@@ -248,7 +248,7 @@ UnitState fetchUnitState(int unitAddr)
   int offsetLSB = Wire.read();
   int offset = (offsetMSB << 8) | offsetLSB;
   int magneticZeroPositionLetterIndex = Wire.read();
-  return UnitState{rotating, offset, magneticZeroPositionLetterIndex, lastResponseAtMillis};
+  return UnitState{unitAddr, rotating, offset, magneticZeroPositionLetterIndex, lastResponseAtMillis};
 }
 
 void fetchAndSetUnitStates()
@@ -294,6 +294,7 @@ void updateUnitStatesStringCache()
     for (int i = 0; i < numUnits; i++)
     {
       UnitState unitState = unitStates[i];
+      j["avrs"][i]["unitAddr"] = unitState.unitAddr;
       j["avrs"][i]["rotating"] = unitState.rotating;
       j["avrs"][i]["magneticZeroPositionLetterIndex"] = unitState.magneticZeroPositionLetterIndex;
       j["avrs"][i]["offset"] = unitState.offset;

--- a/FlapFunctions.h
+++ b/FlapFunctions.h
@@ -5,6 +5,7 @@
 #include "stringHandling.h"
 
 struct UnitState {
+    int unitAddr;
     bool rotating;
     int offset;
     int magneticZeroPositionLetterIndex;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -380,7 +380,7 @@ export default function App() {
 									title="Magnetic Zero Position Letter"
 									dataIndex="magneticZeroPositionLetterIndex"
 									key="magneticZeroPositionLetterIndex"
-									render={(magneticZeroPositionLetterIndex, _record, index) => {
+									render={(magneticZeroPositionLetterIndex, record) => {
 										return (
 											<Select
 												className='w-24'
@@ -400,7 +400,7 @@ export default function App() {
 													setUnitStates((current) => ({
 														...current,
 														avrs: current.avrs.map((avr, i) => {
-															if (i === index) {
+															if (i === record.unitAddr) {
 																return {
 																	...avr,
 																	offset: parseInt(suggestedOffset),
@@ -432,7 +432,7 @@ export default function App() {
 											</Popover>
 										</span>}
 									dataIndex="offset" key="offset"
-									render={(offset, _record, index) => (
+									render={(offset, record) => (
 										<InputNumber
 											className='max-w-20'
 											type="number"
@@ -449,7 +449,7 @@ export default function App() {
 												setUnitStates((current) => ({
 													...current,
 													avrs: current.avrs.map((avr, i) => {
-														if (i === index) {
+														if (i === record.unitAddr) {
 															return {
 																...avr,
 																offset: parseInt(value)


### PR DESCRIPTION
This pull request includes several changes to improve JSON handling and unit state management in the `ESP.ino`, `FlapFunctions.cpp`, and `App.tsx` files. The changes enhance error handling, ensure proper unit address usage, and improve the handling of JSON data.

### JSON Handling Improvements:
* [`ESP.ino`](diffhunk://#diff-80ee4e1dcc65328811e83fe3ae68b9e3ac572aff74a391371c9c4e5be439d342L289-R310): Enhanced the JSON parsing mechanism by appending data chunks to `jsonString` and checking if all data has been received before parsing. Added error handling for invalid JSON and cleared `jsonString` after processing.

### Unit State Management:
* [`ESP.ino`](diffhunk://#diff-80ee4e1dcc65328811e83fe3ae68b9e3ac572aff74a391371c9c4e5be439d342L301-R330): Added checks for `PARAM_OFFSET_UNIT_ADDR` and updated the loop to properly handle unit addresses.
* [`FlapFunctions.cpp`](diffhunk://#diff-7e726b51060b94c0b42cfd19b5a50f5f5230f0032970815e19328cc6dca25303L66-R66): Updated the `commitStagedUnitStates` function to use `unitAddr` from `stagedUnitStates` and added `unitAddr` to the `UnitState` structure. [[1]](diffhunk://#diff-7e726b51060b94c0b42cfd19b5a50f5f5230f0032970815e19328cc6dca25303L66-R66) [[2]](diffhunk://#diff-96ed73ff051ae59d1baf65b6e428a3ae458c4821f1e5378fde249ae5a677b905R8)
* [`FlapFunctions.cpp`](diffhunk://#diff-7e726b51060b94c0b42cfd19b5a50f5f5230f0032970815e19328cc6dca25303L251-R251): Modified `fetchUnitState` to include `unitAddr` in the returned `UnitState` and updated `updateUnitStatesStringCache` to include `unitAddr` in the JSON output. [[1]](diffhunk://#diff-7e726b51060b94c0b42cfd19b5a50f5f5230f0032970815e19328cc6dca25303L251-R251) [[2]](diffhunk://#diff-7e726b51060b94c0b42cfd19b5a50f5f5230f0032970815e19328cc6dca25303R297)

### Frontend Adjustments:
* [`App.tsx`](diffhunk://#diff-2e5aec0d80c33c218d97cb48edb61724a5e25bfc33478de5907916a90a92accfL383-R383): Updated the rendering logic in the `App` component to use `record.unitAddr` instead of `index` for identifying units, ensuring consistency with backend changes. [[1]](diffhunk://#diff-2e5aec0d80c33c218d97cb48edb61724a5e25bfc33478de5907916a90a92accfL383-R383) [[2]](diffhunk://#diff-2e5aec0d80c33c218d97cb48edb61724a5e25bfc33478de5907916a90a92accfL403-R403) [[3]](diffhunk://#diff-2e5aec0d80c33c218d97cb48edb61724a5e25bfc33478de5907916a90a92accfL435-R435) [[4]](diffhunk://#diff-2e5aec0d80c33c218d97cb48edb61724a5e25bfc33478de5907916a90a92accfL452-R452)